### PR TITLE
Testing

### DIFF
--- a/src/Bazaari/Http.hs
+++ b/src/Bazaari/Http.hs
@@ -654,7 +654,7 @@ signatureToParam ::
      ByteString
   -> [(ByteString, Maybe ByteString)]
 signatureToParam s =
-  [ ( "SecretKey"
+  [ ( "Signature"
     , Just s ) ]
 
 getEligibleShippingServices ::

--- a/src/Bazaari/Http.hs
+++ b/src/Bazaari/Http.hs
@@ -664,11 +664,19 @@ getEligibleShippingServices ::
   -> AccessKeyId
   -> ShipmentRequestDetails
   -> IO (Response LB.ByteString)
-getEligibleShippingServices ep sk sid akid srds = do
-  time <- getCurrentTime
-  httpLBS $ setRequestQueryString
-          ( request time )
-          $ makeQuery ep
+getEligibleShippingServices ep sk sid akid srds =
+  httpLBS =<< ( getEligibleShippingServicesRequest ep sk sid akid srds <$> getCurrentTime )
+
+getEligibleShippingServicesRequest ::
+     Endpoint
+  -> SecretKey
+  -> SellerId
+  -> AccessKeyId
+  -> ShipmentRequestDetails
+  -> UTCTime
+  -> Request
+getEligibleShippingServicesRequest ep sk sid akid srds time =
+  setRequestQueryString ( request time ) $ makeQuery ep
   where
     signature params = encode . sign
               $ getEligibleShippingServicesUnsigned ep params

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -59,7 +59,7 @@ sample_ShipmentRequestDetails =
 sample_QueryString :: IO (ByteString, UTCTime)
 sample_QueryString = do
   now <- getCurrentTime
-  sellerId <- envBS "MWS_DEV_SELLER_ID"
+  sellerId <- envBS "MWS_SELLER_ID"
   accessKeyId <- envBS "MWS_DEV_ACCESS_KEY_ID"
   return ( "POST\nmws.amazonservices.com\n/\nAWSAccessKeyId="
         <> accessKeyId

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,7 +9,11 @@ import System.Environment
 import Data.Time
 import Test.Hspec
 import Text.Email.Validate
+import Network.HTTP.Simple
 import Network.HTTP.Types.URI
+import qualified Data.ByteString.Lazy as LB
+       (toStrict
+       ,ByteString)
 
 sample_ShipmentRequestDetails :: ShipmentRequestDetails
 sample_ShipmentRequestDetails =
@@ -68,12 +72,32 @@ sample_QueryString = do
 envBS :: String -> IO ByteString
 envBS envVar = renderEnvironmentVariable <$> getEnv envVar
 
+sendRequest :: IO (Response LB.ByteString)
+sendRequest = do
+  (sk, sid, akid) <- getCreds
+  getEligibleShippingServices NorthAmerica sk sid akid sample_ShipmentRequestDetails
+
+makeRequest :: IO Request
+makeRequest = do
+  now <- getCurrentTime
+  (sk, sid, akid) <- getCreds
+  return $ getEligibleShippingServicesRequest
+             NorthAmerica sk sid akid
+               sample_ShipmentRequestDetails now
+
+getCreds :: IO (ByteString, ByteString, ByteString)
+getCreds = do
+  sk <- envBS "MWS_DEV_SECRET_KEY"
+  sid <- envBS "MWS_SELLER_ID"
+  akid <- envBS "MWS_DEV_ACCESS_KEY_ID"
+  return (sk, sid, akid)
+
 main :: IO ()
 main = hspec $ do
   describe "Unsigned Query" $ do
     it "Test ShipmentRequestDetails should produce a proper unsigned query string." $ do
       (str, now) <- sample_QueryString
-      sellerId <- envBS "MWS_DEV_SELLER_ID"
+      sellerId <- envBS "MWS_SELLER_ID"
       accessKeyId <- envBS "MWS_DEV_ACCESS_KEY_ID"
       getEligibleShippingServicesUnsigned NorthAmerica
         (getEligibleShippingServicesUnsignedParams


### PR DESCRIPTION
Made a getEligibleShippingServicesRequest pure function and made makeRequest and sendRequest test functions that pull environment variables.

As a result of looking at the signed query string before sending using makeRequest, I was able to change the signature to be parameterized as 'Signature' rather than 'SecretKey'.  This changed the error I get when I send the request.  Now instead of a broken pipe I get Connection refused:

**\* Exception: FailedConnectionException2 "mws.amazonservices.com" 80 True connect: does not exist (Connection refused)
